### PR TITLE
feat(mounts): add bind mounts for containers

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -30,6 +30,9 @@ export interface SingleContainerConfig {
   // when to start your tests? how to make sure container is running?
   // see below for options
   wait?: WaitConfig;
+  // array of mounts to bind local (host's) files or directories into the container file system
+  // see below to know how to specify a bind
+  bindMounts?: BindMount[];
 }
 
 export type EnvironmentVariableMap = { [key: string]: string };
@@ -50,4 +53,19 @@ interface TextWaitConfig {
   // part of the string that will be seen on the console output line
   text: string;
 }
+
+export interface BindConfig {
+  // path to the host machine's path to bind
+  source: string;
+  // path to the guest machine (container) where it will be bound
+  target: string;
+  // whether if we grant wrant permissions
+  mode: BindMode;
+}
+
+// permissions of the bound directory / file
+// ro: readonly
+// rw: read and write
+export type BindMode = "ro" | "rw";
+
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trendyol/jest-testcontainers",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -20,7 +20,14 @@ describe("config", () => {
         wait: {
           timeout: 42,
           type: "ports"
-        }
+        },
+        bindMounts: [
+          {
+            source: "some path on host",
+            target: "some path on container",
+            mode: "ro"
+          }
+        ]
       };
       const objInput: any = { first: firstContainer, second: secondContainer };
       const expectedConfig: JestTestcontainersConfig = {
@@ -40,7 +47,14 @@ describe("config", () => {
           wait: {
             timeout: 42,
             type: "ports"
-          }
+          },
+          bindMounts: [
+            {
+              source: "some path on host",
+              target: "some path on container",
+              mode: "ro"
+            }
+          ]
         }
       };
 
@@ -182,6 +196,60 @@ describe("config", () => {
       ].map(wait => ({
         ...baseObjInput,
         first: { ...baseObjInput.first, wait }
+      }));
+
+      // Act
+      const expectResults = inputs.map(input =>
+        expect(() => parseConfig(input))
+      );
+
+      // Assert
+      for (const expectResult of expectResults) {
+        expectResult.toThrow();
+      }
+    });
+
+    it("wrong bind mounts should throw", () => {
+      // Arrange
+      const baseObjInput = {
+        first: {
+          image: "redis"
+        }
+      };
+      const inputs = [
+        null,
+        42,
+        "a weird string mount, like something:somevalue",
+        {
+          source: "a bind mount out of an array",
+          target: "a bind mount out of an array",
+          mode: "rw"
+        },
+        ["an array of non-object bind mounts"],
+        [
+          {
+            source: "a bind mount with just source path"
+          }
+        ],
+        [
+          {
+            target: "a bind mount with just target path"
+          }
+        ],
+        [
+          {
+            mode: "a bind mount with just mode"
+          }
+        ],
+        [
+          {
+            source: "a bind mount with just source and target paths",
+            target: "a bind mount with just source and target paths"
+          }
+        ]
+      ].map(bindMounts => ({
+        ...baseObjInput,
+        first: { ...baseObjInput.first, bindMounts }
       }));
 
       // Act

--- a/src/containers.spec.ts
+++ b/src/containers.spec.ts
@@ -34,6 +34,7 @@ describe("containers", () => {
       expect(actualContainer.startupTimeout).toEqual(
         new Duration(60000, TemporalUnit.MILLISECONDS)
       );
+      expect(actualContainer.bindMounts).toEqual([]);
     });
 
     it("should set tag correctly", () => {
@@ -55,6 +56,7 @@ describe("containers", () => {
       expect(actualContainer.startupTimeout).toEqual(
         new Duration(60000, TemporalUnit.MILLISECONDS)
       );
+      expect(actualContainer.bindMounts).toEqual([]);
     });
 
     it("should set ports correctly", () => {
@@ -76,6 +78,7 @@ describe("containers", () => {
       expect(actualContainer.startupTimeout).toEqual(
         new Duration(60000, TemporalUnit.MILLISECONDS)
       );
+      expect(actualContainer.bindMounts).toEqual([]);
     });
 
     it("should set name correctly", () => {
@@ -99,6 +102,7 @@ describe("containers", () => {
       expect(actualContainer.startupTimeout).toEqual(
         new Duration(60000, TemporalUnit.MILLISECONDS)
       );
+      expect(actualContainer.bindMounts).toEqual([]);
     });
 
     it("should set env correctly", () => {
@@ -122,6 +126,7 @@ describe("containers", () => {
       expect(actualContainer.startupTimeout).toEqual(
         new Duration(60000, TemporalUnit.MILLISECONDS)
       );
+      expect(actualContainer.bindMounts).toEqual([]);
     });
 
     it("should port wait strategy correctly", () => {
@@ -146,6 +151,7 @@ describe("containers", () => {
       expect(actualContainer.startupTimeout).toEqual(
         new Duration(30, TemporalUnit.SECONDS)
       );
+      expect(actualContainer.bindMounts).toEqual([]);
     });
 
     it("should text wait strategy correctly", () => {
@@ -172,6 +178,50 @@ describe("containers", () => {
       expect(actualContainer.startupTimeout).toEqual(
         new Duration(60000, TemporalUnit.MILLISECONDS)
       );
+      expect(actualContainer.bindMounts).toEqual([]);
+    });
+    it("should set bind mounts correctly", () => {
+      // Arrange
+      const config: SingleContainerConfig = {
+        image: "redis",
+        bindMounts: [
+          {
+            source: "/somepath",
+            target: "/somepath",
+            mode: "ro"
+          },
+          {
+            source: "/anotherpath",
+            target: "/anotherpath",
+            mode: "ro"
+          }
+        ]
+      };
+
+      // Act
+      const actualContainer: any = buildTestcontainer(config);
+
+      // Assert
+      expect(actualContainer.image).toEqual("redis");
+      expect(actualContainer.tag).toEqual("latest");
+      expect(actualContainer.ports).toEqual([]);
+      expect(actualContainer.env).toEqual({});
+      expect(actualContainer.waitStrategy).toEqual(undefined);
+      expect(actualContainer.startupTimeout).toEqual(
+        new Duration(60000, TemporalUnit.MILLISECONDS)
+      );
+      expect(actualContainer.bindMounts).toEqual([
+        {
+          source: "/somepath",
+          target: "/somepath",
+          bindMode: "ro"
+        },
+        {
+          source: "/anotherpath",
+          target: "/anotherpath",
+          bindMode: "ro"
+        }
+      ]);
     });
   });
 

--- a/src/containers.ts
+++ b/src/containers.ts
@@ -8,7 +8,8 @@ import {
   EnvironmentVariableMap,
   JestTestcontainersConfig,
   SingleContainerConfig,
-  WaitConfig
+  WaitConfig,
+  BindConfig
 } from "./config";
 
 const addWaitStrategyToContainer = (waitStrategy?: WaitConfig) => (
@@ -49,6 +50,17 @@ const addPortsToContainer = (ports?: number[]) => (
   return container.withExposedPorts(...ports);
 };
 
+const addBindsToContainer = (bindMounts?: BindConfig[]) => (
+  container: TestContainer
+): TestContainer => {
+  if (!bindMounts) return container;
+
+  for (const bindMount of bindMounts) {
+    container.withBindMount(bindMount.source, bindMount.target, bindMount.mode);
+  }
+  return container;
+};
+
 const addNameToContainer = (name?: string) => (
   container: GenericContainer
 ): TestContainer => {
@@ -61,13 +73,14 @@ const addNameToContainer = (name?: string) => (
 export function buildTestcontainer(
   containerConfig: SingleContainerConfig
 ): TestContainer {
-  const { image, tag, ports, name, env, wait } = containerConfig;
+  const { image, tag, ports, name, env, wait, bindMounts } = containerConfig;
   const container = new GenericContainer(image, tag);
 
   return [
     addPortsToContainer(ports),
     addEnvironmentVariablesToContainer(env),
-    addWaitStrategyToContainer(wait)
+    addWaitStrategyToContainer(wait),
+    addBindsToContainer(bindMounts)
   ].reduce<TestContainer>(
     (res, func) => func(res),
     addNameToContainer(name)(container)


### PR DESCRIPTION
Add support for bind mounts leveraging the `testcontainers` library feature:

https://github.com/testcontainers/testcontainers-node/blob/90a6e5cd213baa3c47c0c39abf894def14838a09/src/generic-container.ts#L106-L117

It's great when you have to run some custom scripts to init the container (for instance some SQL queries to create the database schema in relational databases)