### PR TITLE
add inferring watch mode and not restarting containers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trendyol/jest-testcontainers",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trendyol/jest-testcontainers",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Jest preset for starting docker containers that stay up whilist your tests run.",
   "main": "dist/index",
   "types": "dist/index",

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -28,7 +28,11 @@ function createGlobalVariablesFromMetaInfos(
   }, {});
 }
 
-async function setup() {
+async function setup(opts: any) {
+  if ((opts.watch || opts.watchAll) && global.__TESTCONTAINERS__) {
+    return;
+  }
+
   const jestTestcontainersConfig = configReader();
   const allStartedContainersMetaInfo = await startAllContainers(
     jestTestcontainersConfig

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -29,7 +29,11 @@ function createGlobalVariablesFromMetaInfos(
 }
 
 async function setup(opts: any) {
-  if ((opts.watch || opts.watchAll) && global.__TESTCONTAINERS__) {
+  if (
+    !process.env.JEST_TESTCONTAINERS_RESTART_ON_WATCH &&
+    (opts.watch || opts.watchAll) &&
+    global.__TESTCONTAINERS__
+  ) {
     return;
   }
 

--- a/src/teardown.spec.ts
+++ b/src/teardown.spec.ts
@@ -12,11 +12,28 @@ describe("teardown", () => {
       (global as any)[CONTAINERS_GLOBAL_VARIABLE_KEY] = mocks;
 
       // Act
-      await teardown();
+      await teardown({});
 
       // Assert
       for (const { stop: mockCallback } of mocks) {
         expect(mockCallback.mock.calls.length).toBe(1);
+      }
+    });
+
+    it("should not call stop if started in watch mode", async () => {
+      // Arrange
+      const mocks = [...new Array(5)].map(() => ({
+        stop: jest.fn(() => Promise.resolve())
+      }));
+
+      (global as any)[CONTAINERS_GLOBAL_VARIABLE_KEY] = mocks;
+
+      // Act
+      await teardown({ watch: true });
+
+      // Assert
+      for (const { stop: mockCallback } of mocks) {
+        expect(mockCallback.mock.calls.length).toBe(0);
       }
     });
   });

--- a/src/teardown.ts
+++ b/src/teardown.ts
@@ -1,7 +1,10 @@
 import { StartedContainerAndMetaInfo } from "./containers";
 
 async function teardown(opts: any) {
-  if (opts.watch || opts.watchAll) {
+  if (
+    !process.env.JEST_TESTCONTAINERS_RESTART_ON_WATCH &&
+    (opts.watch || opts.watchAll)
+  ) {
     return;
   }
 

--- a/src/teardown.ts
+++ b/src/teardown.ts
@@ -1,6 +1,10 @@
 import { StartedContainerAndMetaInfo } from "./containers";
 
-async function teardown() {
+async function teardown(opts: any) {
+  if (opts.watch || opts.watchAll) {
+    return;
+  }
+
   const allStartedContainers: StartedContainerAndMetaInfo[] = (global as any)
     .__TESTCONTAINERS__;
 


### PR DESCRIPTION
This PR fixes the issue mentioned in #18 by inferring watch mode and not restarting the started containers.